### PR TITLE
Potential fix for the IE 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MDN: [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
 ## Usage
 
 ```
-import '@benlesh/event-target-polyfill';
+import 'event-target-polyfill';
 
 const et = new EventTarget();
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const root =
   (typeof self !== "undefined" && self) ||
   (typeof global !== "undefined" && global);
 
-if (typeof root.Event === "undefined") {
+if (typeof root.Event === "undefined" || typeof root.Event === "object") {
   root.Event = (function () {
     function Event(type, options) {
       if (options) {


### PR DESCRIPTION
Follow up to #1

It seems, that minimal required change would be checking if `typeof Event` is `"object"`.

It should be `"function"` in all browsers that support `new Event()` (I am referring to [this quite old stackoverflow question](https://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work)), although I'm not quite sure how safe this actually is.