### PR TITLE
Add constructor test

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (typeof root.Event === "undefined") {
   })();
 }
 
-if (typeof root.EventTarget === "undefined") {
+if (typeof root.EventTarget === "undefined" || !(function () { try { return new EventTarget() } catch { return 0 } }())) {
   root.EventTarget = (function () {
     function EventTarget() {
       this.__listeners = new Map();


### PR DESCRIPTION
Some JS contexts (such  as Cloudflare Workers) have a global `EventTarget`, but won't allow constructing new instances.

This PR adds a condition that checks if the constructor throws and overwrites the implementation in that case.